### PR TITLE
Fix building of docs on CI

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,7 @@
 [deps]
-HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
 BialkaliSpectrum = "35893526-f1dd-48d2-8180-97f6707ed43b"
-WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"
+WignerSymbols = "9f57e263-0b3d-5e2e-b1be-24f2bb48858b"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,7 @@ makedocs(
             "Analyzing the results" => "api/analyzing_spectrum.md"
         ]
     ],
-    # strict = true
+    strict = true
 )
 
 deploydocs(

--- a/docs/src/man/basics.md
+++ b/docs/src/man/basics.md
@@ -9,23 +9,22 @@ Pages = ["basics.md"]
 This package is not yet registered with the Julia package manager.
 
 From the REPL, do
-```@repl
-import Pkg
-Pkg.add(url="https://github.com/kylematsuda/BialkaliSpectrum.jl")
-nothing; # hide
+```julia
+julia> import Pkg
+julia> Pkg.add(url="https://github.com/kylematsuda/BialkaliSpectrum.jl")
 ```
 
 Now bring the package contents into scope:
 
-```jldoctest bialkali
-julia> using BialkaliSpectrum
+```@repl bialkali
+using BialkaliSpectrum
 ```
 
 You can optionally also pull in molecule-specific definitions, which are kept
 in different submodules (`BialkaliSpectrum.K40Rb87`, `BialkaliSpectrum.Toy`, etc.):
 
-```jldoctest bialkali
-julia> using BialkaliSpectrum.K40Rb87 # optional, brings all KRb-specific stuff into scope
+```@repl bialkali
+using BialkaliSpectrum.K40Rb87 # optional, brings all KRb-specific stuff into scope
 ```
 
 ## First calculation
@@ -35,11 +34,9 @@ julia> using BialkaliSpectrum.K40Rb87 # optional, brings all KRb-specific stuff 
 Before doing the calculation, we need to do a little bit of setup: 
 construct the Hamiltonian and choose the external fields to use in the calculation:
 
-```jldoctest bialkali
-julia> parts = make_krb_hamiltonian_parts(5);
-
-julia> fields = ExternalFields(545.9, 0.0, []) # B = 545.9 G, E = 0, no optical fields
-ExternalFields(SphericalVector(545.9, 0.0, 0.0), SphericalVector(0.0, 0.0, 0.0), SphericalVector[])
+```@repl bialkali
+parts = make_krb_hamiltonian_parts(5);
+fields = ExternalFields(545.9, 0.0, []) # B = 545.9 G, E = 0, no optical fields
 ```
 
 ### Finding the energy levels
@@ -47,51 +44,15 @@ ExternalFields(SphericalVector(545.9, 0.0, 0.0), SphericalVector(0.0, 0.0, 0.0),
 Next, we call [`get_spectrum`](@ref), which diagonalizes the Hamiltonian
 (constructed from `parts`) at `fields`.
 
-```jldoctest bialkali
-julia> spectrum = get_spectrum(parts, fields)
-1296×13 DataFrame
-  Row │ fields                             index  energy        eigenstate     ⋯
-      │ External…                          Int64  Float64       SubArray…      ⋯
-──────┼─────────────────────────────────────────────────────────────────────────
-    1 │ ExternalFields(SphericalVector(5…      1     -1.6672    ComplexF64[3.9 ⋯
-    2 │ ExternalFields(SphericalVector(5…      2     -1.53563   ComplexF64[-8.
-    3 │ ExternalFields(SphericalVector(5…      3     -1.40404   ComplexF64[4.0
-    4 │ ExternalFields(SphericalVector(5…      4     -1.27245   ComplexF64[-6.
-    5 │ ExternalFields(SphericalVector(5…      5     -1.14086   ComplexF64[0.0 ⋯
-    6 │ ExternalFields(SphericalVector(5…      6     -1.00925   ComplexF64[0.0
-    7 │ ExternalFields(SphericalVector(5…      7     -0.914827  ComplexF64[4.8
-    8 │ ExternalFields(SphericalVector(5…      8     -0.877637  ComplexF64[0.0
-  ⋮   │                 ⋮                    ⋮         ⋮                       ⋱
- 1290 │ ExternalFields(SphericalVector(5…   1290  33420.2       ComplexF64[0.0 ⋯
- 1291 │ ExternalFields(SphericalVector(5…   1291  33420.2       ComplexF64[2.5
- 1292 │ ExternalFields(SphericalVector(5…   1292  33420.3       ComplexF64[0.0
- 1293 │ ExternalFields(SphericalVector(5…   1293  33420.3       ComplexF64[0.0
- 1294 │ ExternalFields(SphericalVector(5…   1294  33420.3       ComplexF64[0.0 ⋯
- 1295 │ ExternalFields(SphericalVector(5…   1295  33420.3       ComplexF64[0.0
- 1296 │ ExternalFields(SphericalVector(5…   1296  33420.4       ComplexF64[6.4
-                                                10 columns and 1281 rows omitted
-
+```@repl bialkali
+spectrum = get_spectrum(parts, fields)
 ```
 
 The output is a [`DataFrame`](https://dataframes.juliadata.org/stable/).
 We can inspect its columns:
 
-```jldoctest bialkali
-julia> names(spectrum)
-13-element Vector{String}:
- "fields"
- "index"
- "energy"
- "eigenstate"
- "basis_index"
- "N"
- "m_n"
- "I_1"
- "m_i1"
- "I_2"
- "m_i2"
- "B"
- "E"
+```@repl bialkali
+names(spectrum)
 ```
 
 Descriptions of these fields can be found in the documentation for [`get_spectrum`](@ref).
@@ -105,84 +66,11 @@ of [`get_spectrum`](@ref).
 Documentation of these methods can be found here: [DataFrame helpers](@ref).
 Let's try a few of them:
 
-```jldoctest bialkali
-julia> filter_rotational(spectrum, 0, 0) # get only the N = 0, m_N = 0 states
-36×13 DataFrame
- Row │ fields                             index  energy     eigenstate         ⋯
-     │ External…                          Int64  Float64    SubArray…          ⋯
-─────┼──────────────────────────────────────────────────────────────────────────
-   1 │ ExternalFields(SphericalVector(5…      1  -1.6672    ComplexF64[3.97483 ⋯
-   2 │ ExternalFields(SphericalVector(5…      2  -1.53563   ComplexF64[-8.1453
-   3 │ ExternalFields(SphericalVector(5…      3  -1.40404   ComplexF64[4.08372
-   4 │ ExternalFields(SphericalVector(5…      4  -1.27245   ComplexF64[-6.9833
-   5 │ ExternalFields(SphericalVector(5…      5  -1.14086   ComplexF64[0.0-0.0 ⋯
-   6 │ ExternalFields(SphericalVector(5…      6  -1.00925   ComplexF64[0.0-0.0
-   7 │ ExternalFields(SphericalVector(5…      7  -0.914827  ComplexF64[4.87699
-   8 │ ExternalFields(SphericalVector(5…      8  -0.877637  ComplexF64[0.0-0.0
-  ⋮  │                 ⋮                    ⋮        ⋮                      ⋮  ⋱
-  30 │ ExternalFields(SphericalVector(5…     30   0.92291   ComplexF64[0.0-0.0 ⋯
-  31 │ ExternalFields(SphericalVector(5…     31   1.00312   ComplexF64[1.6655e
-  32 │ ExternalFields(SphericalVector(5…     32   1.14082   ComplexF64[-4.7147
-  33 │ ExternalFields(SphericalVector(5…     33   1.27851   ComplexF64[-2.2568
-  34 │ ExternalFields(SphericalVector(5…     34   1.41619   ComplexF64[0.0-0.0 ⋯
-  35 │ ExternalFields(SphericalVector(5…     35   1.55387   ComplexF64[0.0-0.0
-  36 │ ExternalFields(SphericalVector(5…     36   1.69154   ComplexF64[0.0-0.0
-                                                  10 columns and 21 rows omitted
-
-julia> filter_rotational(spectrum, [1, 2, 3]) # get everything in N = 1, 2, 3
-540×13 DataFrame
- Row │ fields                             index  energy    eigenstate          ⋯
-     │ External…                          Int64  Float64   SubArray…           ⋯
-─────┼──────────────────────────────────────────────────────────────────────────
-   1 │ ExternalFields(SphericalVector(5…     37   2226.11  ComplexF64[0.0-0.0i ⋯
-   2 │ ExternalFields(SphericalVector(5…     38   2226.2   ComplexF64[0.0-0.0i
-   3 │ ExternalFields(SphericalVector(5…     39   2226.22  ComplexF64[0.0-0.0i
-   4 │ ExternalFields(SphericalVector(5…     40   2226.28  ComplexF64[0.0-0.0i
-   5 │ ExternalFields(SphericalVector(5…     41   2226.31  ComplexF64[0.0-0.0i ⋯
-   6 │ ExternalFields(SphericalVector(5…     42   2226.37  ComplexF64[0.0-0.0i
-   7 │ ExternalFields(SphericalVector(5…     43   2226.42  ComplexF64[0.0-0.0i
-   8 │ ExternalFields(SphericalVector(5…     44   2226.44  ComplexF64[0.0-0.0i
-  ⋮  │                 ⋮                    ⋮       ⋮                      ⋮   ⋱
- 534 │ ExternalFields(SphericalVector(5…    570  13369.1   ComplexF64[0.0-0.0i ⋯
- 535 │ ExternalFields(SphericalVector(5…    571  13369.1   ComplexF64[0.0-0.0i
- 536 │ ExternalFields(SphericalVector(5…    572  13369.1   ComplexF64[0.0-0.0i
- 537 │ ExternalFields(SphericalVector(5…    573  13369.1   ComplexF64[0.0-0.0i
- 538 │ ExternalFields(SphericalVector(5…    574  13369.2   ComplexF64[0.0-0.0i ⋯
- 539 │ ExternalFields(SphericalVector(5…    575  13369.2   ComplexF64[0.0-0.0i
- 540 │ ExternalFields(SphericalVector(5…    576  13369.2   ComplexF64[0.0-0.0i
-                                                 10 columns and 525 rows omitted
-
-julia> filter_hyperfine(spectrum, -4, [1/2, 3/2]) # get m_K = -4, m_Rb = 1/2 or 3/2 states
-72×13 DataFrame
- Row │ fields                             index  energy        eigenstate      ⋯
-     │ External…                          Int64  Float64       SubArray…       ⋯
-─────┼──────────────────────────────────────────────────────────────────────────
-   1 │ ExternalFields(SphericalVector(5…      1     -1.6672    ComplexF64[3.97 ⋯
-   2 │ ExternalFields(SphericalVector(5…      7     -0.914827  ComplexF64[4.87
-   3 │ ExternalFields(SphericalVector(5…     37   2226.11      ComplexF64[0.0-
-   4 │ ExternalFields(SphericalVector(5…     39   2226.22      ComplexF64[0.0-
-   5 │ ExternalFields(SphericalVector(5…     40   2226.28      ComplexF64[0.0- ⋯
-   6 │ ExternalFields(SphericalVector(5…     54   2226.87      ComplexF64[0.0-
-   7 │ ExternalFields(SphericalVector(5…     56   2226.92      ComplexF64[0.0-
-   8 │ ExternalFields(SphericalVector(5…     66   2227.19      ComplexF64[0.0-
-  ⋮  │                 ⋮                    ⋮         ⋮                        ⋱
-  66 │ ExternalFields(SphericalVector(5…    976  33417.6       ComplexF64[1.27 ⋯
-  67 │ ExternalFields(SphericalVector(5…    979  33417.7       ComplexF64[-1.5
-  68 │ ExternalFields(SphericalVector(5…    983  33417.7       ComplexF64[-1.1
-  69 │ ExternalFields(SphericalVector(5…    984  33417.7       ComplexF64[1.47
-  70 │ ExternalFields(SphericalVector(5…    988  33417.7       ComplexF64[3.47 ⋯
-  71 │ ExternalFields(SphericalVector(5…    992  33417.7       ComplexF64[9.27
-  72 │ ExternalFields(SphericalVector(5…    993  33417.7       ComplexF64[1.16
-                                                  10 columns and 57 rows omitted
-
-julia> filter_basis_state(spectrum, KRbState(2, 2, -3, -1/2)) # get the states whose nearest basis state is |2, 2, -3, 1/2>
-1×13 DataFrame
- Row │ fields                             index  energy   eigenstate           ⋯
-     │ External…                          Int64  Float64  SubArray…            ⋯
-─────┼──────────────────────────────────────────────────────────────────────────
-   1 │ ExternalFields(SphericalVector(5…    225  6683.58  ComplexF64[-5.56021e ⋯
-                                                              10 columns omitted
-
+```@repl bialkali
+filter_rotational(spectrum, 0, 0) # get only the N = 0, m_N = 0 states
+filter_rotational(spectrum, [1, 2, 3]) # get everything in N = 1, 2, 3
+filter_hyperfine(spectrum, -4, [1/2, 3/2]) # get m_K = -4, m_Rb = 1/2 or 3/2 states
+filter_basis_state(spectrum, KRbState(2, 2, -3, -1/2)) # get the states whose nearest basis state is |2, 2, -3, 1/2>
 ```
 
 All of these methods copy the results into a new `DataFrame` to avoid mutating the


### PR DESCRIPTION
Docs don't build correctly on CI, there are a lot of doctest failures.

Unfortunately these are not currently marked as failing in CI.

Add `strict=true` to `makedocs` as a first step, hopefully this results in the failing doctests being flagged correctly